### PR TITLE
Janky TaskItem equality check to verify performance

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -672,36 +672,10 @@ namespace Microsoft.Build.BackEnd
 
         public class DeepItemEqualityComparer : IEqualityComparer<TaskItem>
         {
-            private Dictionary<TaskItem, int> hashCache = new Dictionary<TaskItem, int>(ReferenceEqualityComparer.Instance);
-
             public bool Equals(TaskItem x, TaskItem y) => x.Equals(y);
             public int GetHashCode(TaskItem obj)
             {
-                // return obj.GetHashCodeDeep();
-
-                if (!hashCache.TryGetValue(obj, out int hashCode))
-                {
-                    hashCode = obj.GetHashCodeDeep();
-                    hashCache[obj] = hashCode;
-                }
-
-                return hashCode;
-            }
-        }
-
-        public class ReferenceEqualityComparer : IEqualityComparer<TaskItem>
-        {
-            public static ReferenceEqualityComparer Instance = new ReferenceEqualityComparer();
-
-            bool IEqualityComparer<TaskItem>.Equals(TaskItem x, TaskItem y) => object.ReferenceEquals(x, y);
-            int IEqualityComparer<TaskItem>.GetHashCode(TaskItem obj)
-            {
-                if (obj == null)
-                {
-                    return 0;
-                }
-
-                return obj.GetHashCode();
+                return obj.GetHashCodeDeep();
             }
         }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -677,14 +677,15 @@ namespace Microsoft.Build.BackEnd
             public bool Equals(TaskItem x, TaskItem y) => x.Equals(y);
             public int GetHashCode(TaskItem obj)
             {
+                return obj.GetHashCodeDeep();
 
-                if (!hashCache.TryGetValue(obj, out int hashCode))
-                {
-                    hashCode = obj.GetHashCodeDeep();
-                    hashCache[obj] = hashCode;
-                }
+                // if (!hashCache.TryGetValue(obj, out int hashCode))
+                // {
+                //     hashCode = obj.GetHashCodeDeep();
+                //     hashCache[obj] = hashCode;
+                // }
 
-                return hashCode;
+                // return hashCode;
             }
         }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -672,20 +672,36 @@ namespace Microsoft.Build.BackEnd
 
         public class DeepItemEqualityComparer : IEqualityComparer<TaskItem>
         {
-            private Dictionary<TaskItem, int> hashCache = new Dictionary<TaskItem, int>();
+            private Dictionary<TaskItem, int> hashCache = new Dictionary<TaskItem, int>(ReferenceEqualityComparer.Instance);
 
             public bool Equals(TaskItem x, TaskItem y) => x.Equals(y);
             public int GetHashCode(TaskItem obj)
             {
-                return obj.GetHashCodeDeep();
+                // return obj.GetHashCodeDeep();
 
-                // if (!hashCache.TryGetValue(obj, out int hashCode))
-                // {
-                //     hashCode = obj.GetHashCodeDeep();
-                //     hashCache[obj] = hashCode;
-                // }
+                if (!hashCache.TryGetValue(obj, out int hashCode))
+                {
+                    hashCode = obj.GetHashCodeDeep();
+                    hashCache[obj] = hashCode;
+                }
 
-                // return hashCode;
+                return hashCode;
+            }
+        }
+
+        public class ReferenceEqualityComparer : IEqualityComparer<TaskItem>
+        {
+            public static ReferenceEqualityComparer Instance = new ReferenceEqualityComparer();
+
+            bool IEqualityComparer<TaskItem>.Equals(TaskItem x, TaskItem y) => object.ReferenceEquals(x, y);
+            int IEqualityComparer<TaskItem>.GetHashCode(TaskItem obj)
+            {
+                if (obj == null)
+                {
+                    return 0;
+                }
+
+                return obj.GetHashCode();
             }
         }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -19,7 +19,7 @@ using ProjectLoggingContext = Microsoft.Build.BackEnd.Logging.ProjectLoggingCont
 using TargetLoggingContext = Microsoft.Build.BackEnd.Logging.TargetLoggingContext;
 using TaskItem = Microsoft.Build.Execution.ProjectItemInstance.TaskItem;
 
-#if MSBUILDENABLEVSPROFILING 
+#if MSBUILDENABLEVSPROFILING
 using Microsoft.VisualStudio.Profiler;
 #endif
 #nullable disable
@@ -507,7 +507,7 @@ namespace Microsoft.Build.BackEnd
                                 // We either have some work to do or at least we need to infer outputs from inputs.
                                 bucketResult = await ProcessBucket(taskBuilder, targetLoggingContext, GetTaskExecutionMode(dependencyResult), lookupForInference, lookupForExecution);
 
-                                // Now aggregate the result with the existing known results.  There are four rules, assuming the target was not 
+                                // Now aggregate the result with the existing known results.  There are four rules, assuming the target was not
                                 // skipped due to being up-to-date:
                                 // 1. If this bucket failed or was cancelled, the aggregate result is failure.
                                 // 2. If this bucket Succeeded and we have not previously failed, the aggregate result is a success.
@@ -525,7 +525,7 @@ namespace Microsoft.Build.BackEnd
                                     }
                                 }
 
-                                // Pop the lookup scopes, causing them to collapse their values back down into the 
+                                // Pop the lookup scopes, causing them to collapse their values back down into the
                                 // bucket's lookup.
                                 // NOTE: this order is important because when we infer outputs, we are trying
                                 // to produce the same results as would be produced from a full build; as such
@@ -557,7 +557,7 @@ namespace Microsoft.Build.BackEnd
                     }
                     finally
                     {
-                        // Don't log the last target finished event until we can process the target outputs as we want to attach them to the 
+                        // Don't log the last target finished event until we can process the target outputs as we want to attach them to the
                         // last target batch.
                         if (targetLoggingContext != null && i < numberOfBuckets - 1)
                         {
@@ -585,13 +585,13 @@ namespace Microsoft.Build.BackEnd
                     string targetReturns = _target.Returns;
                     ElementLocation targetReturnsLocation = _target.ReturnsLocation;
 
-                    // If there are no targets in the project file that use the "Returns" attribute, that means that we 
+                    // If there are no targets in the project file that use the "Returns" attribute, that means that we
                     // revert to the legacy behavior in the case where Returns is not specified (null, rather
-                    // than the empty string, which indicates no returns).  Legacy behavior is for all 
-                    // of the target's Outputs to be returned. 
-                    // On the other hand, if there is at least one target in the file that uses the Returns attribute, 
+                    // than the empty string, which indicates no returns).  Legacy behavior is for all
+                    // of the target's Outputs to be returned.
+                    // On the other hand, if there is at least one target in the file that uses the Returns attribute,
                     // then all targets in the file are run according to the new behaviour (return nothing unless otherwise
-                    // specified by the Returns attribute). 
+                    // specified by the Returns attribute).
                     if (targetReturns == null)
                     {
                         if (!_target.ParentProjectSupportsReturnsAttribute)
@@ -616,7 +616,7 @@ namespace Microsoft.Build.BackEnd
 
                         // NOTE: we need to gather the outputs in batches, because the output specification may reference item metadata
                         // Also, we are using the baseLookup, which has possibly had changes made to it since the project started.  Because of this, the
-                        // set of outputs calculated here may differ from those which would have been calculated at the beginning of the target.  It is 
+                        // set of outputs calculated here may differ from those which would have been calculated at the beginning of the target.  It is
                         // assumed the user intended this.
                         List<ItemBucket> batchingBuckets = BatchingEngine.PrepareBatchingBuckets(GetBatchableParametersForTarget(), _baseLookup, _target.Location);
 
@@ -629,7 +629,8 @@ namespace Microsoft.Build.BackEnd
                         }
                         else
                         {
-                            HashSet<TaskItem> addedItems = new HashSet<TaskItem>();
+
+                            HashSet<TaskItem> addedItems = new HashSet<TaskItem>(new DeepItemEqualityComparer());
                             foreach (ItemBucket bucket in batchingBuckets)
                             {
                                 IList<TaskItem> itemsToAdd = bucket.Expander.ExpandIntoTaskItemsLeaveEscaped(targetReturns, ExpanderOptions.ExpandAll, targetReturnsLocation);
@@ -648,7 +649,7 @@ namespace Microsoft.Build.BackEnd
                 }
                 finally
                 {
-                    // log the last target finished since we now have the target outputs. 
+                    // log the last target finished since we now have the target outputs.
                     targetLoggingContext?.LogTargetBatchFinished(projectFullPath, targetSuccess, targetOutputItems?.Count > 0 ? targetOutputItems : null);
                 }
 
@@ -666,6 +667,24 @@ namespace Microsoft.Build.BackEnd
             finally
             {
                 _isExecuting = false;
+            }
+        }
+
+        public class DeepItemEqualityComparer : IEqualityComparer<TaskItem>
+        {
+            private Dictionary<TaskItem, int> hashCache = new Dictionary<TaskItem, int>();
+
+            public bool Equals(TaskItem x, TaskItem y) => x.Equals(y);
+            public int GetHashCode(TaskItem obj)
+            {
+
+                if (!hashCache.TryGetValue(obj, out int hashCode))
+                {
+                    hashCode = obj.GetHashCodeDeep();
+                    hashCache[obj] = hashCode;
+                }
+
+                return hashCode;
             }
         }
 

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1498,6 +1498,45 @@ namespace Microsoft.Build.Execution
                 return StringComparer.OrdinalIgnoreCase.GetHashCode(ItemSpec);
             }
 
+            public int GetHashCodeDeep()
+            {
+                var hash = this.GetHashCode();
+
+                // var thisNames = new HashSet<string>(MSBuildNameIgnoreCaseComparer.Default);
+
+                // if (_itemDefinitions is not null)
+                // {
+                //     foreach (ProjectItemDefinitionInstance itemDefinition in _itemDefinitions)
+                //     {
+                //         thisNames.UnionWith(itemDefinition.MetadataNames);
+                //     }
+                // }
+
+                // if (_directMetadata is not null)
+                // {
+                //     foreach (ProjectMetadataInstance metadatum in _directMetadata)
+                //     {
+                //         thisNames.Add(metadatum.Name);
+                //     }
+                // }
+
+                // ITaskItem2 thisAsITaskItem2 = this;
+
+                // foreach(var name in thisNames)
+                // {
+                //     var value = thisAsITaskItem2.GetMetadataValueEscaped(name).ToLowerInvariant();
+                //     hash = hash * 23 + value.GetHashCode();
+                // }
+
+                foreach (var metadatum in this.MetadataCollection)
+                {
+                    hash = hash * 23 + metadatum.Name.ToLowerInvariant().GetHashCode();
+                    hash = hash * 23 + metadatum.EvaluatedValueEscaped.ToLowerInvariant().GetHashCode();
+                }
+
+                return hash;
+            }
+
             /// <summary>
             /// Override of Equals
             /// </summary>


### PR DESCRIPTION
There is a big performance hit in the de-duping path because there can be lots of hash collisions in the hashset used here.  Since we only care about the hashset here for the de-duping stuff, we can use a hashcode that includes all the object metadata which may enable us to be more performant here with large numbers of items.  

This is intended to be a proof of concept ONLY!